### PR TITLE
Feature/autofill hints

### DIFF
--- a/lib/src/features/registration/presentation/otp_screen.dart
+++ b/lib/src/features/registration/presentation/otp_screen.dart
@@ -66,6 +66,7 @@ class _OTPScreenState extends ConsumerState<OTPScreen> {
                         padding: const EdgeInsets.all(8.0),
                         child: LabeledTextFormField(
                             controller: codeController,
+                            inputType: TextInputType.number,
                             autofillHints: [AutofillHints.oneTimeCode],
                             labelText: "Código"),
                       ),

--- a/lib/src/features/registration/presentation/registration_screen.dart
+++ b/lib/src/features/registration/presentation/registration_screen.dart
@@ -130,6 +130,8 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                   controller: nameController,
                   labelText: "Nombre(s)",
                   inputType: TextInputType.name,
+                  autofillHints: [AutofillHints.givenName],
+                  textInputAction: TextInputAction.next,
                   validator: (value) {
                     if (value == null || value.isEmpty) {
                       return appLocalization.errorRequiredField;
@@ -144,6 +146,8 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                   controller: lastNameController,
                   labelText: "Apellido(s)",
                   inputType: TextInputType.name,
+                  autofillHints: [AutofillHints.familyName],
+                  textInputAction: TextInputAction.next,
                   validator: (value) {
                     if (value == null || value.isEmpty) {
                       return appLocalization.errorRequiredField;
@@ -175,6 +179,7 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                               style: Theme.of(context).textTheme.bodyText1,
                               controller: phoneController,
                               keyboardType: TextInputType.phone,
+                              autofillHints: [AutofillHints.telephoneNumber],
                               validator: (value) {
                                 if (value == null || value.isEmpty) {
                                   return appLocalization.errorRequiredField;
@@ -227,6 +232,8 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                   controller: emailController,
                   labelText: "Correo electrónico",
                   inputType: TextInputType.emailAddress,
+                  autofillHints: [AutofillHints.email],
+                  textInputAction: TextInputAction.next,
                   validator: (value) {
                     if (value == null || value.isEmpty) {
                       return appLocalization.errorRequiredField;
@@ -244,6 +251,8 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                   controller: passwordController,
                   labelText: "Contraseña",
                   obscure: obscurePassword,
+                  autofillHints: [AutofillHints.newPassword],
+                  textInputAction: TextInputAction.next,
                   suffixIcon: GestureDetector(
                     onTap: () {
                       setState(() {
@@ -272,6 +281,7 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                   controller: confirmPasswordController,
                   labelText: "Confirmar contraseña",
                   obscure: obscureConfirmPassword,
+                  textInputAction: TextInputAction.done,
                   suffixIcon: GestureDetector(
                     onTap: () {
                       setState(() {

--- a/lib/src/shared/components/alcancia_text_field.dart
+++ b/lib/src/shared/components/alcancia_text_field.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
 
 class LabeledTextFormField extends StatelessWidget {
-  const LabeledTextFormField(
-      {Key? key,
-      required this.controller,
-      required this.labelText,
-      this.suffixIcon,
-      this.obscure = false,
-      this.autofillHints,
-      this.inputType,  this.validator,})
-      : super(key: key);
+  const LabeledTextFormField({
+    Key? key,
+    required this.controller,
+    required this.labelText,
+    this.suffixIcon,
+    this.obscure = false,
+    this.autofillHints,
+    this.textInputAction,
+    this.inputType,
+    this.validator,
+  }) : super(key: key);
 
   final TextEditingController controller;
   final String labelText;
@@ -18,6 +20,7 @@ class LabeledTextFormField extends StatelessWidget {
   final String? Function(String?)? validator;
   final TextInputType? inputType;
   final Iterable<String>? autofillHints;
+  final TextInputAction? textInputAction;
 
   @override
   Widget build(BuildContext context) {
@@ -29,6 +32,7 @@ class LabeledTextFormField extends StatelessWidget {
           controller: controller,
           keyboardType: inputType,
           autofillHints: autofillHints,
+          textInputAction: textInputAction,
           obscureText: obscure,
           decoration: InputDecoration(
             suffixIcon: suffixIcon,


### PR DESCRIPTION
## Summary
Add autofill hints to registration screen (login screen pending for alcancia website)

## Requirements
N/A

## Type of change
- [x] feature
- [ ] hotfix
- [ ] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
Run the app on a real device, go through registration process. Your device should suggest values for every field except password confirmation.

## How has this been tested?
- [ ] Every field in registration screen should suggest a relevant value

## Screenshots
N/A

## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?