### PR TITLE
Fix/late user verification

### DIFF
--- a/lib/src/features/login/data/login_mutation.dart
+++ b/lib/src/features/login/data/login_mutation.dart
@@ -3,7 +3,8 @@ const String loginMutation = """
     login(loginUserInput: \$loginUserInput) {
       access_token,
       user {
-        userId,
+        id,
+        authId,
         name,
         surname,
         gender,

--- a/lib/src/features/registration/data/signup_mutation.dart
+++ b/lib/src/features/registration/data/signup_mutation.dart
@@ -1,7 +1,8 @@
 const String signupMutation = """
   mutation(\$signupUserInput: CreateUserInput!) {
     signup(signupUserInput: \$signupUserInput) {
-      userId,
+      id,
+      authId,
       name,
       surname,
       email,

--- a/lib/src/features/registration/presentation/otp_screen.dart
+++ b/lib/src/features/registration/presentation/otp_screen.dart
@@ -1,9 +1,9 @@
-import 'package:alcancia/src/features/registration/model/user_registration_model.dart';
 import 'package:alcancia/src/features/registration/provider/registration_controller_provider.dart';
 import 'package:alcancia/src/features/registration/provider/timer_provider.dart';
 import 'package:alcancia/src/resources/colors/colors.dart';
 import 'package:alcancia/src/shared/components/alcancia_components.dart';
 import 'package:alcancia/src/shared/components/alcancia_snack_bar.dart';
+import 'package:alcancia/src/shared/models/otp_data_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter/cupertino.dart';
@@ -12,8 +12,8 @@ import 'package:stop_watch_timer/stop_watch_timer.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class OTPScreen extends ConsumerStatefulWidget {
-  OTPScreen({Key? key, required this.userRegistrationData}) : super(key: key);
-  final UserRegistrationModel userRegistrationData;
+  OTPScreen({Key? key, required this.otpDataModel}) : super(key: key);
+  final OTPDataModel otpDataModel;
   final Uri url = Uri.parse('');
 
   @override
@@ -21,9 +21,16 @@ class OTPScreen extends ConsumerStatefulWidget {
 }
 
 class _OTPScreenState extends ConsumerState<OTPScreen> {
-  final codeController = TextEditingController();
-  String error = "";
+  final _codeController = TextEditingController();
+  String _error = "";
   bool _loading = false;
+
+  String _bodyText() {
+    if (widget.otpDataModel.phoneNumber != null) {
+      return "Ingresa el código de 6 dígitos que enviamos a tu celular ${widget.otpDataModel.phoneNumber}";
+    }
+    return "Ingresa el código de 6 dígitos que enviamos a tu celular";
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,20 +65,20 @@ class _OTPScreenState extends ConsumerState<OTPScreen> {
                       Padding(
                         padding: EdgeInsets.all(8.0),
                         child: Text(
-                            "Ingresa el código de 6 dígitos que enviamos a tu celular ${widget.userRegistrationData.user.phoneNumber}"),
+                          _bodyText(),
+                        ),
                       ),
                       Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: LabeledTextFormField(
-                            controller: codeController,
+                            controller: _codeController,
                             autofillHints: [AutofillHints.oneTimeCode],
                             labelText: "Código"),
                       ),
                       StreamBuilder<int>(
                           stream: timer.rawTime,
                           initialData: 0,
-                          builder:
-                              (BuildContext ctx, AsyncSnapshot snapshot) {
+                          builder: (BuildContext ctx, AsyncSnapshot snapshot) {
                             final value = snapshot.data;
                             final displayTime = StopWatchTimer.getDisplayTime(
                                 value,
@@ -98,8 +105,8 @@ class _OTPScreenState extends ConsumerState<OTPScreen> {
                                           ),
                                           Text(
                                             displayTime,
-                                            style:
-                                                TextStyle(color: alcanciaLightBlue),
+                                            style: TextStyle(
+                                                color: alcanciaLightBlue),
                                           ),
                                         ],
                                       ),
@@ -113,15 +120,16 @@ class _OTPScreenState extends ConsumerState<OTPScreen> {
                                     TextButton(
                                       onPressed: value <= 0
                                           ? () async {
-                                        await registrationController
-                                            .resendVerificationCode(widget.userRegistrationData.user.email);
-                                        timer.onResetTimer();
-                                        timer.onStartTimer();
-                                      }
+                                              await registrationController
+                                                  .resendVerificationCode(widget
+                                                      .otpDataModel
+                                                      .email);
+                                              timer.onResetTimer();
+                                              timer.onStartTimer();
+                                            }
                                           : null,
                                       style: TextButton.styleFrom(
-                                          foregroundColor: alcanciaLightBlue
-                                      ),
+                                          foregroundColor: alcanciaLightBlue),
                                       child: const Text(
                                         "Reenviar",
                                         style: TextStyle(
@@ -150,22 +158,22 @@ class _OTPScreenState extends ConsumerState<OTPScreen> {
                                   _setLoading(true);
                                   try {
                                     await registrationController.verifyOTP(
-                                        codeController.text,
-                                        widget.userRegistrationData.user.email);
+                                        _codeController.text,
+                                        widget.otpDataModel.email);
                                     ScaffoldMessenger.of(context).showSnackBar(
                                         AlcanciaSnackBar(context,
                                             "Tu cuenta ha sido creada exitosamente."));
                                     context.go("/login");
                                   } catch (err) {
                                     setState(() {
-                                      error = err.toString();
+                                      _error = err.toString();
                                     });
                                   }
                                   _setLoading(false);
                                 },
                               ),
                               Text(
-                                error,
+                                _error,
                                 style: const TextStyle(color: Colors.red),
                               ),
                             ],
@@ -185,7 +193,7 @@ class _OTPScreenState extends ConsumerState<OTPScreen> {
 
   @override
   void dispose() {
-    codeController.dispose();
+    _codeController.dispose();
     super.dispose();
   }
 

--- a/lib/src/features/registration/presentation/phone_registration_screen.dart
+++ b/lib/src/features/registration/presentation/phone_registration_screen.dart
@@ -1,4 +1,5 @@
 import 'package:alcancia/src/features/registration/provider/timer_provider.dart';
+import 'package:alcancia/src/shared/models/otp_data_model.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -167,7 +168,8 @@ class _OTPMethodScreenState extends ConsumerState<PhoneRegistrationScreen> {
                             timer.setPresetMinuteTime(1, add: false);
                             timer.onResetTimer();
                             timer.onStartTimer();
-                            context.push("/otp", extra: widget.userRegistrationData);
+                            final email = widget.userRegistrationData.user.email;
+                            context.push("/otp", extra: OTPDataModel(email: email, phoneNumber: phoneNumber));
                           } catch (e) {
                             setState(() {
                               error =

--- a/lib/src/features/registration/presentation/registration_screen.dart
+++ b/lib/src/features/registration/presentation/registration_screen.dart
@@ -260,7 +260,8 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
                   height: 64,
                   onPressed: () {
                     final user = User(
-                      userId: "",
+                      id: "",
+                      authId: "",
                       name: nameController.text,
                       surname: lastNameController.text,
                       email: emailController.text,

--- a/lib/src/shared/graphql/queries.dart
+++ b/lib/src/shared/graphql/queries.dart
@@ -1,7 +1,7 @@
 const String meQuery = """
   query {
     me {
-      userId,
+      authId,
       surname,
       gender,
       phoneNumber,

--- a/lib/src/shared/graphql/queries/me_query.dart
+++ b/lib/src/shared/graphql/queries/me_query.dart
@@ -1,7 +1,8 @@
 const String meQuery = """
   query {
     me {
-      userId,
+      id,
+      authId,
       surname,
       gender,
       country,

--- a/lib/src/shared/models/otp_data_model.dart
+++ b/lib/src/shared/models/otp_data_model.dart
@@ -1,0 +1,5 @@
+class OTPDataModel {
+  const OTPDataModel({required this.email, this.phoneNumber});
+  final String email;
+  final String? phoneNumber;
+}

--- a/lib/src/shared/models/user_model.dart
+++ b/lib/src/shared/models/user_model.dart
@@ -2,7 +2,8 @@ import 'package:alcancia/src/shared/models/transaction_model.dart';
 import 'package:intl/intl.dart';
 
 class User {
-  final String userId;
+  final String id;
+  final String authId;
   final String email;
   final String name;
   final String surname;
@@ -16,7 +17,8 @@ class User {
   double userProfit;
 
   User({
-    required this.userId,
+    required this.id,
+    required this.authId,
     required this.surname,
     required this.gender,
     required this.country,
@@ -30,7 +32,8 @@ class User {
   });
 
   static final sampleUser = User(
-      userId: "",
+      id: "",
+      authId: "",
       surname: "",
       gender: "",
       country: "",
@@ -43,7 +46,8 @@ class User {
 
   factory User.fromJSON(Map<String, dynamic> map) {
     return User(
-      userId: map["userId"],
+      id: map["id"],
+      authId: map["authId"],
       surname: map["surname"],
       gender: map["gender"],
       country: map["country"],

--- a/lib/src/shared/provider/router_provider.dart
+++ b/lib/src/shared/provider/router_provider.dart
@@ -1,5 +1,4 @@
 import 'package:alcancia/src/features/registration/presentation/phone_registration_screen.dart';
-import 'package:alcancia/src/screens/dashboard/dashboard_screen.dart';
 import 'package:alcancia/src/features/login/presentation/login_screen.dart';
 import 'package:alcancia/src/features/registration/model/GraphQLConfig.dart';
 import 'package:alcancia/src/features/swap/presentation/swap_screen.dart';
@@ -13,6 +12,7 @@ import 'package:alcancia/src/shared/components/alcancia_tabbar.dart';
 import 'package:alcancia/src/shared/graphql/queries.dart';
 import 'package:alcancia/src/shared/models/alcancia_models.dart';
 import 'package:alcancia/src/shared/models/login_data_model.dart';
+import 'package:alcancia/src/shared/models/otp_data_model.dart';
 import 'package:alcancia/src/shared/models/transaction_model.dart';
 import 'package:alcancia/src/shared/services/storage_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -84,7 +84,7 @@ final routerProvider = Provider<GoRouter>(
           name: "otp",
           path: "/otp",
           builder: (context, state) => OTPScreen(
-            userRegistrationData: state.extra as UserRegistrationModel,
+            otpDataModel: state.extra as OTPDataModel,
           ),
         ),
         GoRoute(

--- a/lib/src/shared/provider/user_provider.dart
+++ b/lib/src/shared/provider/user_provider.dart
@@ -8,7 +8,8 @@ class UserState extends StateNotifier<User?> {
   Future<void> login(String email, String password) async {
     // This mocks some sort of request / response
     state = User(
-      userId: "",
+      id: "",
+      authId: "",
       name: "My Name",
       surname: "My Surname",
       email: "My Email",


### PR DESCRIPTION
## Summary
Sends unverified user to OTP screen to finish sign up verification process after attempting to login.

## Requirements
N/A

## Type of change
- [ ] feature
- [ ] hotfix
- [x] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
Register a new account without verifying the phone number, close the app, open the app again and try to login with the new account. The app should send you to the OTP screen and ask for the verification code again.

## How has this been tested?
- [ ] Unverified account sends to OTP
- [ ] Verified account sends to MFA screen

## Screenshots
N/A

## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?