### PR TITLE
fix: retrieve exchange rate from suarmi instead of exchange rate api

### DIFF
--- a/lib/src/screens/swap/swap_controller.dart
+++ b/lib/src/screens/swap/swap_controller.dart
@@ -1,0 +1,31 @@
+import 'dart:developer';
+
+import 'package:alcancia/src/shared/services/exception_service.dart';
+import 'package:alcancia/src/shared/services/suarmi_service.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+class SwapController {
+  final _exceptionHandler = ExceptionService();
+  final _suarmiService = SuarmiService();
+
+  final suarmiQuoteInput = {
+    "quoteInput": {
+      "from_amount": "1",
+      "from_currency": "MXN",
+      "network": "MATIC",
+      "to_currency": "USDC",
+    }
+  };
+
+  getSuarmiExchange() async {
+    var response = await _suarmiService.getSuarmiQuote(suarmiQuoteInput);
+    if (response.hasException) {
+      print('exception:');
+      var exception = _exceptionHandler.handleException(response.exception);
+      print(exception);
+      throw Exception(exception);
+    }
+    print(response.data);
+    return response.data?['getSuarmiQuote']['to_amount'];
+  }
+}

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -1,0 +1,300 @@
+import 'package:alcancia/src/resources/colors/colors.dart';
+import 'package:alcancia/src/screens/metamap/metamap_controller.dart';
+import 'package:alcancia/src/screens/swap/swap_controller.dart';
+import 'package:alcancia/src/shared/components/alcancia_components.dart';
+import 'package:alcancia/src/shared/components/alcancia_container.dart';
+import 'package:alcancia/src/shared/components/alcancia_dropdown.dart';
+import 'package:alcancia/src/shared/components/alcancia_link.dart';
+import 'package:alcancia/src/shared/components/alcancia_toolbar.dart';
+import 'package:alcancia/src/shared/provider/user_provider.dart';
+import 'package:alcancia/src/shared/services/responsive_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:go_router/go_router.dart';
+import 'package:alcancia/src/screens/metamap/metamap_dialog.dart';
+
+class SwapScreen extends ConsumerStatefulWidget {
+  const SwapScreen({Key? key}) : super(key: key);
+
+  @override
+  ConsumerState<SwapScreen> createState() => _SwapScreenState();
+}
+
+class _SwapScreenState extends ConsumerState<SwapScreen> {
+  // source amount vars
+  late String sourceAmount = ""; // value entered in text field
+  final sourceAmountController = TextEditingController();
+
+  // source amount icons
+  final List<Map> sourceCurrencyCodes = [
+    {"name": "MXN", "icon": "lib/src/resources/images/icon_mexico_flag.png"},
+    {"name": "DOP", "icon": "lib/src/resources/images/icon_dominican_flag.png"},
+  ];
+
+  // target amount icons
+  final List<Map> targetCurrencies = [
+    {"name": "USDC", "icon": "lib/src/resources/images/icon_usdc.png"},
+  ];
+
+  // dropdown value for source currency, it can be MXN or DOP
+  late String sourceCurrency = sourceCurrencyCodes.first['name'];
+  final ResponsiveService responsiveService = ResponsiveService();
+
+  // metamap
+  final MetaMapController metaMapController = MetaMapController();
+  final metamapDomicanFlowId = dotenv.env['DOMINICAN_FLOW_ID'] as String;
+  final metamapMexicanResidentId = dotenv.env['MEXICO_RESIDENTS_FLOW_ID'] as String;
+  final metamapMexicanINEId = dotenv.env['MEXICO_INE_FLOW_ID'] as String;
+
+  final SwapController swapController = SwapController();
+  var suarmiExchage = 1.0;
+
+  // state
+  bool _isLoading = false;
+  String _error = "";
+
+  getExchange() async {
+    setState(() {
+      _isLoading = true;
+    });
+    try {
+      var exchageRate = await swapController.getSuarmiExchange();
+      setState(() {
+        suarmiExchage = 1.0 / double.parse(exchageRate);
+      });
+    } catch (err) {
+      // print(err);
+      _error = err.toString();
+    }
+    setState(() {
+      _isLoading = false;
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    getExchange();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var user = ref.watch(userProvider);
+
+    final txtTheme = Theme.of(context).textTheme;
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    if (_isLoading) {
+      return const SafeArea(child: Center(child: CircularProgressIndicator()));
+    }
+
+    if (_error != "") return Scaffold(body: SafeArea(child: Center(child: Text(_error))));
+
+    return GestureDetector(
+      onTap: () {
+        FocusManager.instance.primaryFocus?.unfocus();
+      },
+      child: Scaffold(
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                AlcanciaToolbar(
+                  state: StateToolbar.logoNoletters,
+                  logoHeight: responsiveService.getHeightPixels(40, screenHeight),
+                ),
+
+                // general container, sets padding
+                AlcanciaContainer(
+                  top: 20,
+                  left: 30,
+                  right: 30,
+                  bottom: 34,
+                  child: Column(
+                    children: [
+                      AlcanciaContainer(
+                        top: 4,
+                        bottom: 32,
+                        child: Text("Deposita a tu cuenta", style: txtTheme.subtitle1),
+                      ),
+                      AlcanciaContainer(
+                        bottom: 32,
+                        child: Text("¡Empecemos!", style: txtTheme.headline1),
+                      ),
+                      AlcanciaContainer(
+                        bottom: 30,
+                        child: Text(
+                          "Ingresa el monto que deseas convertir de nuestra opciones. A continuación, se presenta a cuanto equivale en",
+                          style: txtTheme.bodyText1,
+                        ),
+                      ),
+                      Container(
+                        padding: EdgeInsets.only(
+                          top: responsiveService.getHeightPixels(20, screenHeight),
+                          bottom: responsiveService.getHeightPixels(20, screenHeight),
+                          left: responsiveService.getWidthPixels(12, screenWidth),
+                          right: responsiveService.getWidthPixels(12, screenWidth),
+                        ),
+                        decoration: BoxDecoration(
+                          color:
+                              Theme.of(context).brightness == Brightness.dark ? alcanciaCardDark : alcanciaFieldLight,
+                          borderRadius: const BorderRadius.all(Radius.circular(7)),
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text("¿Cuánto deseas convertir?", style: txtTheme.bodyText1),
+                            AlcanciaContainer(
+                              top: 8,
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  AlcanciaDropdown(
+                                    dropdownWidth: responsiveService.getWidthPixels(150, screenWidth),
+                                    dropdownHeight: responsiveService.getHeightPixels(45, screenHeight),
+                                    dropdownItems: sourceCurrencyCodes,
+                                    onChanged: (newValue) {
+                                      setState(() {
+                                        sourceCurrency = newValue;
+                                        print(sourceCurrency);
+                                        // when this components intis, we will exchange rate from suarmi and cryptopay
+                                      });
+                                    },
+                                  ),
+                                  // this is the input field where user enters source amount
+                                  AlcanciaContainer(
+                                    height: 45,
+                                    width: 150,
+                                    child: TextField(
+                                      style: const TextStyle(fontSize: 15),
+                                      decoration: InputDecoration(
+                                        fillColor: Theme.of(context).primaryColor,
+                                      ),
+                                      inputFormatters: <TextInputFormatter>[FilteringTextInputFormatter.digitsOnly],
+                                      keyboardType: TextInputType.number,
+                                      controller: sourceAmountController,
+                                      onChanged: (text) {
+                                        setState(() {
+                                          sourceAmount = text;
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8, bottom: 8),
+                              child: Center(child: SvgPicture.asset("lib/src/resources/images/arrow_down_purple.svg")),
+                            ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                AlcanciaDropdown(
+                                  dropdownWidth: responsiveService.getWidthPixels(150, screenWidth),
+                                  dropdownHeight: responsiveService.getHeightPixels(45, screenHeight),
+                                  dropdownItems: targetCurrencies,
+                                ),
+                                // here is where target amount is display
+                                Container(
+                                  padding: const EdgeInsets.only(left: 10),
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(8),
+                                    color: Theme.of(context).primaryColor,
+                                  ),
+                                  height: responsiveService.getHeightPixels(45, screenHeight),
+                                  width: responsiveService.getWidthPixels(150, screenWidth),
+                                  alignment: Alignment.centerLeft,
+                                  child: Text(
+                                    sourceAmount == ""
+                                        ? ""
+                                        : (int.parse(sourceAmountController.text) / suarmiExchage).toStringAsFixed(4),
+                                    style: txtTheme.bodyText1,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                      Container(
+                        alignment: Alignment.topLeft,
+                        padding: const EdgeInsets.only(
+                          top: 32,
+                        ),
+                        child: Text(
+                          "Medio de pago:",
+                          style: txtTheme.bodyText1,
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 10, bottom: 12),
+                        child: AlcanciaButton(
+                          buttonText: "Transferencia",
+                          onPressed: () async {
+                            //Temporary Variables
+                            var verified = user!.kycStatus;
+                            var resident = false;
+
+                            if (verified == "VERIFIED") {
+                              context.push('/');
+                              // go to checkout form
+                            } else if (verified == "PENDING") {
+                              Fluttertoast.showToast(
+                                  msg: "Revisión en proceso, espera un momento...",
+                                  toastLength: Toast.LENGTH_LONG,
+                                  gravity: ToastGravity.BOTTOM);
+                            } else if (verified == "FAILED" || verified == null) {
+                              if (sourceCurrency == 'MXN') {
+                                final UserStatus status = await showDialog(
+                                  context: context,
+                                  builder: (BuildContext context) {
+                                    return const UserStatusDialog();
+                                  },
+                                );
+                                resident = status == UserStatus.resident;
+                              }
+                              if (sourceCurrency == 'MXN' && resident) {
+                                metaMapController.showMatiFlow(metamapMexicanResidentId, user.id);
+                              }
+
+                              if (sourceCurrency == 'MXN' && !resident) {
+                                metaMapController.showMatiFlow(metamapMexicanINEId, user.id);
+                              }
+
+                              if (sourceCurrency == "DOP") {
+                                metaMapController.showMatiFlow(metamapDomicanFlowId, user.id);
+                              }
+                            }
+                          },
+                          color: alcanciaLightBlue,
+                          width: double.infinity,
+                          height: responsiveService.getHeightPixels(64, screenHeight),
+                        ),
+                      ),
+                      AlcanciaContainer(
+                        top: 20,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: const [
+                            Text("¿Tienes alguna inquietud? "),
+                            AlcanciaLink(text: 'Haz click aquí'),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -90,7 +90,7 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     final screenWidth = MediaQuery.of(context).size.width;
 
     if (_isLoading) {
-      return const SafeArea(child: Center(child: CircularProgressIndicator()));
+      return const Scaffold(body: SafeArea(child: Center(child: CircularProgressIndicator())));
     }
 
     if (_error != "") return Scaffold(body: SafeArea(child: Center(child: Text(_error))));

--- a/lib/src/shared/components/alcancia_container.dart
+++ b/lib/src/shared/components/alcancia_container.dart
@@ -1,0 +1,42 @@
+import 'package:alcancia/src/shared/services/responsive_service.dart';
+import 'package:flutter/material.dart';
+
+class AlcanciaContainer extends StatelessWidget {
+  final double? top;
+  final double? bottom;
+  final double? left;
+  final double? right;
+  final double? width;
+  final double? height;
+  final Widget child;
+  final ResponsiveService responsiveService = ResponsiveService();
+
+  AlcanciaContainer({
+    super.key,
+    this.top,
+    this.bottom,
+    this.left,
+    this.right,
+    this.width,
+    this.height,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    return Container(
+      height: height,
+      width: width,
+      padding: EdgeInsets.only(
+        top: top != null ? responsiveService.getHeightPixels(top!, screenHeight) : 0,
+        bottom: bottom != null ? responsiveService.getHeightPixels(bottom!, screenHeight) : 0,
+        left: left != null ? responsiveService.getWidthPixels(left!, screenWidth) : 0,
+        right: right != null ? responsiveService.getWidthPixels(right!, screenWidth) : 0,
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/src/shared/graphql/queries/index.dart
+++ b/lib/src/shared/graphql/queries/index.dart
@@ -1,0 +1,4 @@
+export 'suarmi_quota_query.dart';
+export 'me_query.dart';
+export 'transactions_query.dart';
+export 'walletbalance_query.dart';

--- a/lib/src/shared/graphql/queries/suarmi_quota_query.dart
+++ b/lib/src/shared/graphql/queries/suarmi_quota_query.dart
@@ -1,0 +1,7 @@
+const String suarmiQuota = """
+  query(\$quoteInput: QuoteInput!) {
+    getSuarmiQuote(quoteInput: \$quoteInput){
+      to_amount
+    }
+  }
+""";

--- a/lib/src/shared/provider/router_provider.dart
+++ b/lib/src/shared/provider/router_provider.dart
@@ -2,13 +2,13 @@ import 'package:alcancia/main.dart';
 import 'package:alcancia/src/features/registration/presentation/phone_registration_screen.dart';
 import 'package:alcancia/src/features/login/presentation/login_screen.dart';
 import 'package:alcancia/src/features/registration/model/GraphQLConfig.dart';
-import 'package:alcancia/src/features/swap/presentation/swap_screen.dart';
 import 'package:alcancia/src/features/registration/presentation/otp_screen.dart';
 import 'package:alcancia/src/features/user-profile/presentation/account_screen.dart';
 import 'package:alcancia/src/features/welcome/presentation/welcome_screen.dart';
 import 'package:alcancia/src/features/registration/presentation/registration_screen.dart';
 import 'package:alcancia/src/features/registration/model/user_registration_model.dart';
 import 'package:alcancia/src/screens/login/mfa_screen.dart';
+import 'package:alcancia/src/screens/swap/swap_screen.dart';
 import 'package:alcancia/src/shared/components/alcancia_tabbar.dart';
 import 'package:alcancia/src/shared/graphql/queries.dart';
 import 'package:alcancia/src/shared/models/alcancia_models.dart';
@@ -32,7 +32,7 @@ Future<bool> isUserAuthenticated() async {
 }
 
 final routerProvider = Provider<GoRouter>(
-      (ref) {
+  (ref) {
     return GoRouter(
       navigatorKey: navigatorKey,
       // debugLogDiagnostics: true,
@@ -69,8 +69,8 @@ final routerProvider = Provider<GoRouter>(
         GoRoute(
           name: "phone-registration",
           path: "/phone-registration",
-          builder: (context, state) => PhoneRegistrationScreen(
-              userRegistrationData: state.extra as UserRegistrationModel),
+          builder: (context, state) =>
+              PhoneRegistrationScreen(userRegistrationData: state.extra as UserRegistrationModel),
         ),
         GoRoute(
           name: "swap",
@@ -80,8 +80,7 @@ final routerProvider = Provider<GoRouter>(
         GoRoute(
           name: "transaction_detail",
           path: "/transaction_detail",
-          builder: (context, state) =>
-              TransactionDetail(txn: state.extra as Transaction),
+          builder: (context, state) => TransactionDetail(txn: state.extra as Transaction),
         ),
         GoRoute(
           name: "otp",
@@ -93,8 +92,7 @@ final routerProvider = Provider<GoRouter>(
         GoRoute(
           name: "mfa",
           path: "/mfa",
-          builder: (context, state) =>
-              MFAScreen(data: state.extra as LoginDataModel),
+          builder: (context, state) => MFAScreen(data: state.extra as LoginDataModel),
         )
       ],
       redirect: (context, state) async {

--- a/lib/src/shared/services/exception_service.dart
+++ b/lib/src/shared/services/exception_service.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 class ExceptionService {
@@ -5,6 +7,7 @@ class ExceptionService {
     if (linkException is NetworkException) return linkException.message;
     if (linkException is HttpLinkServerException) return linkException.parsedResponse!.response.toString();
     if (linkException is ServerException) return linkException.originalException.message;
+    if (linkException is OperationException) return linkException?.originalException.toString();
   }
 
   String? handleException(OperationException? exception) {

--- a/lib/src/shared/services/suarmi_service.dart
+++ b/lib/src/shared/services/suarmi_service.dart
@@ -1,0 +1,31 @@
+// late GraphQLConfig graphQLConfig;
+// late Future<GraphQLClient> client;
+
+// TransactionsService() {
+//   graphQLConfig = GraphQLConfig();
+//   client = graphQLConfig.clientToQuery();
+// }
+
+import 'package:alcancia/src/shared/graphql/queries/index.dart';
+import 'package:alcancia/src/shared/services/graphql_service.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+class SuarmiService {
+  late GraphQLConfig graphQLConfig;
+  late Future<GraphQLClient> client;
+
+  SuarmiService() {
+    graphQLConfig = GraphQLConfig();
+    client = graphQLConfig.clientToQuery();
+  }
+
+  Future<QueryResult> getSuarmiQuote(Map<String, dynamic> quoteInput) async {
+    var clientResponse = await client;
+    return await clientResponse.query(
+      QueryOptions(
+        document: gql(suarmiQuota),
+        variables: quoteInput,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Exchange rate for suarmi is now retrive from backend endpoint
- Deleted exchange rate api code
- Made a bit of clean up by creating a new container widget
- I did not remove the old file for swap, instead I created a new one under the screens folder

- Make sure everything works usual in that screen: swap converison and metamap after clicking button

## Requirements
- N / A

## Type of change
- [ ] feature
- [ ] hotfix
- [x] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
1. Open the app
2. Go to swap
3. Enter different amounts
4. You should be able to see the conversion as it was previously

## How has this been tested?
- [ ] When the input field for source amount is empty, so is the target box
- [ ] When user enters source amount, target amount should be display


## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?