### PR TITLE
feat: allow user to copy bank information in suarmi deposit

### DIFF
--- a/lib/src/screens/checkout/checkout.dart
+++ b/lib/src/screens/checkout/checkout.dart
@@ -158,7 +158,7 @@ class OrderInformation extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Text("$suarmiConcept", style: textStyle),
-                      AlcanciaCopyToClipboard(displayText: "Concepto copiado", textToCopy: suarmiConcept as String),
+                      AlcanciaCopyToClipboard(displayText: "Concepto copiad@", textToCopy: suarmiConcept as String),
                     ],
                   ),
                 ],

--- a/lib/src/screens/checkout/checkout.dart
+++ b/lib/src/screens/checkout/checkout.dart
@@ -141,7 +141,7 @@ class OrderInformation extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         Text('${bankInfo[key]}', style: textStyle),
-                        AlcanciaCopyToClipboard(displayText: key, textToCopy: bankInfo[key] as String)
+                        AlcanciaCopyToClipboard(displayText: '$key copiad@', textToCopy: bankInfo[key] as String)
                       ],
                     )
                   ],

--- a/lib/src/screens/checkout/checkout.dart
+++ b/lib/src/screens/checkout/checkout.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer';
 
 import 'package:alcancia/src/shared/components/alcancia_components.dart';
+import 'package:alcancia/src/shared/components/alcancia_copy_clipboard.dart';
 import 'package:alcancia/src/shared/components/alcancia_snack_bar.dart';
 import 'package:alcancia/src/shared/constants.dart';
 import 'package:alcancia/src/shared/models/suarmi_order_model.dart';
@@ -51,7 +52,7 @@ class Checkout extends StatelessWidget {
             if (snapshot.connectionState != ConnectionState.done) return Center(child: CircularProgressIndicator());
             if (snapshot.hasData && snapshot.data!.hasException) {
               final e = exceptionService.handleException(snapshot.data?.exception);
-              return Center(child: Text(e.toString()),);
+              return Center(child: Text(e.toString()));
             }
             var suarmiOrder = SuarmiOrder.fromJson(snapshot.data?.data?["sendSuarmiOrder"]);
             return Padding(
@@ -136,7 +137,13 @@ class OrderInformation extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text('$key:', style: textStyle?.copyWith(fontWeight: FontWeight.bold)),
-                    Text('${bankInfo[key]}', style: textStyle),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text('${bankInfo[key]}', style: textStyle),
+                        AlcanciaCopyToClipboard(displayText: key, textToCopy: bankInfo[key] as String)
+                      ],
+                    )
                   ],
                 ),
               )
@@ -151,18 +158,7 @@ class OrderInformation extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Text("$suarmiConcept", style: textStyle),
-                      InkWell(
-                        child: const Icon(Icons.copy, size: 20, color: Colors.blue),
-                        onTap: () async {
-                          Clipboard.setData(ClipboardData(text: suarmiConcept));
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            AlcanciaSnackBar(
-                              context,
-                              "Concepto copiado",
-                            ),
-                          );
-                        },
-                      )
+                      AlcanciaCopyToClipboard(displayText: "Concepto copiado", textToCopy: suarmiConcept as String),
                     ],
                   ),
                 ],

--- a/lib/src/shared/components/alcancia_copy_clipboard.dart
+++ b/lib/src/shared/components/alcancia_copy_clipboard.dart
@@ -1,0 +1,31 @@
+import 'package:alcancia/src/shared/components/alcancia_snack_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class AlcanciaCopyToClipboard extends StatelessWidget {
+  final String textToCopy;
+  final String displayText;
+
+  const AlcanciaCopyToClipboard({
+    super.key,
+    required this.displayText,
+    required this.textToCopy,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      child: const Icon(
+        Icons.copy,
+        size: 20,
+        color: Colors.blue,
+      ),
+      onTap: () async {
+        Clipboard.setData(ClipboardData(text: textToCopy));
+        ScaffoldMessenger.of(context).showSnackBar(
+          AlcanciaSnackBar(context, displayText),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Added icon to copy suarmi bank information 
- note: I can't send orders to suarmi, so I couldn't tested myself haha

## Type of change
- [x] feature
- [ ] hotfix
- [ ] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
- create a suarmi order
- when bank information is display, you should be able to copy anything related to the bank info

## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?