### PR TITLE
fix: send deviceToken in login reattempt

### DIFF
--- a/lib/src/shared/services/auth_service.dart
+++ b/lib/src/shared/services/auth_service.dart
@@ -84,7 +84,7 @@ class AuthService {
       MutationOptions(
         document: gql(loginMutation),
         variables: {
-          "loginUserInput": {"email": email, "password": password, "token": deviceToken}
+          "loginUserInput": {"email": email, "password": password, "deviceToken": deviceToken}
         },
       ),
     );


### PR DESCRIPTION
## Summary
Fixes 'deviceToken' field wrongfully named 'token' in login mutation called at MFA screen

## Requirements
N/A

## Type of change
- [ ] feature
- [ ] hotfix
- [x] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
Attempt to login, wait for timer to end in MFA screen and click resend button. A login reattempt should happen without any errors from backend

## How has this been tested?


## Screenshots
_add screenshots if need it_

## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?