### PR TITLE
chore: change AlcanciaToolbar to AppBar

### DIFF
--- a/lib/src/features/login/presentation/login_screen.dart
+++ b/lib/src/features/login/presentation/login_screen.dart
@@ -112,9 +112,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   children: [
                     Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: AlcanciaToolbar(
-                        state: StateToolbar.logoNoletters,
-                        logoHeight: size.height / 8,
+                      child: AlcanciaLogo(
+                        height: size.height / 8,
                       ),
                     ),
                     Column(

--- a/lib/src/features/registration/presentation/phone_registration_screen.dart
+++ b/lib/src/features/registration/presentation/phone_registration_screen.dart
@@ -1,5 +1,6 @@
 import 'package:alcancia/src/features/registration/presentation/registration_screen.dart';
 import 'package:alcancia/src/features/registration/provider/timer_provider.dart';
+import 'package:alcancia/src/shared/components/alcancia_container.dart';
 import 'package:alcancia/src/shared/models/otp_data_model.dart';
 import 'package:alcancia/src/shared/services/exception_service.dart';
 import 'package:flutter/gestures.dart';
@@ -23,10 +24,10 @@ class PhoneRegistrationScreen extends ConsumerStatefulWidget {
   final Uri url = Uri.parse('');
 
   @override
-  ConsumerState<PhoneRegistrationScreen> createState() => _OTPMethodScreenState();
+  ConsumerState<PhoneRegistrationScreen> createState() => _PhoneRegistrationScreenState();
 }
 
-class _OTPMethodScreenState extends ConsumerState<PhoneRegistrationScreen> {
+class _PhoneRegistrationScreenState extends ConsumerState<PhoneRegistrationScreen> {
   final selectedCountryProvider = StateProvider.autoDispose<Country>((ref) => countries[0]);
   TextEditingController phoneController = TextEditingController();
   bool acceptTerms = false;
@@ -43,28 +44,29 @@ class _OTPMethodScreenState extends ConsumerState<PhoneRegistrationScreen> {
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: Scaffold(
+        appBar: AlcanciaToolbar(
+          toolbarHeight: size.height / 12,
+          state: StateToolbar.logoLetters,
+          logoHeight: size.height / 12,
+        ),
         body: SafeArea(
           child: Padding(
             padding: const EdgeInsets.only(left: 32.0, right: 32.0, bottom: 32.0),
             child: Column(
               children: [
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: AlcanciaToolbar(
-                    state: StateToolbar.logoLetters,
-                    logoHeight: size.height / 12,
+                AlcanciaContainer(
+                  top: 16,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      Text(
+                        "Número de teléfono",
+                        style: TextStyle(fontWeight: FontWeight.bold, fontSize: 35),
+                      ),
+                      Text("Ingresa tu número de teléfono para recibir tu código de verificación.",
+                          style: TextStyle(fontSize: 15)),
+                    ],
                   ),
-                ),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: const [
-                    Text(
-                      "Número de teléfono",
-                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 35),
-                    ),
-                    Text("Ingresa tu número de teléfono para recibir tu código de verificación.",
-                        style: TextStyle(fontSize: 15)),
-                  ],
                 ),
                 Padding(
                   padding: const EdgeInsets.only(top: 32.0, bottom: 32.0),

--- a/lib/src/features/registration/presentation/registration_screen.dart
+++ b/lib/src/features/registration/presentation/registration_screen.dart
@@ -91,6 +91,11 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: Scaffold(
+        appBar: AlcanciaToolbar(
+          toolbarHeight: size.height / 13,
+          state: StateToolbar.logoLetters,
+          logoHeight: size.height / 16,
+        ),
         body: SafeArea(
           bottom: false,
           child: Form(
@@ -100,13 +105,6 @@ class _RegistrationScreenState extends ConsumerState<RegistrationScreen> {
             child: ListView(
               padding: const EdgeInsets.only(left: 32.0, right: 32.0, bottom: 32.0),
               children: [
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: AlcanciaToolbar(
-                    state: StateToolbar.logoLetters,
-                    logoHeight: size.height / 12,
-                  ),
-                ),
                 Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: const [

--- a/lib/src/features/transactions-list/presentation/transactions_list_screen.dart
+++ b/lib/src/features/transactions-list/presentation/transactions_list_screen.dart
@@ -25,6 +25,11 @@ class TransactionsListScreen extends StatelessWidget {
       builder: (context, AsyncSnapshot snapshot) {
         if (snapshot.connectionState == ConnectionState.done) {
           return Scaffold(
+            appBar: const AlcanciaToolbar(
+              state: StateToolbar.titleIcon,
+              title: 'Actividad',
+              logoHeight: 38,
+            ),
             body: SafeArea(
               child: GraphQLProvider(
                 client: snapshot.data,
@@ -53,21 +58,9 @@ class TransactionsListScreen extends StatelessWidget {
                       padding: const EdgeInsets.only(
                         left: 24,
                         right: 24,
-                        top: 10,
                       ),
-                      child: Column(
-                        children: [
-                          const AlcanciaToolbar(
-                            state: StateToolbar.titleIcon,
-                            title: 'Actividad',
-                            logoHeight: 38,
-                          ),
-                          Expanded(
-                            child: AlcanciaTransactions(
-                              txns: transactionsList,
-                            ),
-                          ),
-                        ],
+                      child: AlcanciaTransactions(
+                        txns: transactionsList,
                       ),
                     );
                   },

--- a/lib/src/features/user-profile/presentation/account_screen.dart
+++ b/lib/src/features/user-profile/presentation/account_screen.dart
@@ -20,16 +20,16 @@ class AccountScreen extends ConsumerWidget {
     final user = ref.watch(userProvider) ?? User.sampleUser;
     final authService = ref.watch(authServiceProvider);
     return Scaffold(
+      appBar: const AlcanciaToolbar(
+        state: StateToolbar.titleIcon,
+        logoHeight: 38,
+        title: "Mi Cuenta",
+      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.only(left: 24.0, right: 24.0, top: 10),
           child: Column(
             children: [
-              AlcanciaToolbar(
-                state: StateToolbar.titleIcon,
-                logoHeight: 38,
-                title: "Mi Cuenta",
-              ),
               GestureDetector(
                 onTap: () {
                   // TODO: Change password

--- a/lib/src/features/welcome/presentation/welcome_screen.dart
+++ b/lib/src/features/welcome/presentation/welcome_screen.dart
@@ -1,4 +1,5 @@
 import 'package:alcancia/src/shared/components/alcancia_button.dart';
+import 'package:alcancia/src/shared/components/alcancia_logo.dart';
 import 'package:alcancia/src/shared/services/responsive_service.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:alcancia/src/resources/colors/colors.dart';
@@ -94,7 +95,12 @@ class WelcomeScreen extends StatelessWidget {
                   )),
                 ),
               ),
-              AlcanciaToolbar(state: StateToolbar.logoNoletters, logoHeight: size.height / 12),
+              Align(
+                alignment: Alignment.topCenter,
+                child: AlcanciaLogo(
+                  height: size.height / 12,
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/src/screens/dashboard/dashboard_screen.dart
+++ b/lib/src/screens/dashboard/dashboard_screen.dart
@@ -5,6 +5,7 @@ import 'package:alcancia/src/resources/colors/colors.dart';
 import 'package:alcancia/src/screens/dashboard/dashboard_controller.dart';
 import 'package:alcancia/src/screens/metamap/metamap_dialog.dart';
 import 'package:alcancia/src/shared/components/alcancia_components.dart';
+import 'package:alcancia/src/shared/components/alcancia_toolbar.dart';
 import 'package:alcancia/src/shared/components/alcancia_transactions_list.dart';
 import 'package:alcancia/src/shared/models/alcancia_models.dart';
 import 'package:alcancia/src/shared/provider/balance_provider.dart';
@@ -85,6 +86,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     if (_error != "") return SafeArea(child: Center(child: Text(_error)));
     var kycStatus = dashboardController.displayKycStatus(user!.kycStatus);
     return Scaffold(
+      appBar: AlcanciaToolbar(state: StateToolbar.profileTitleIcon, logoHeight: 38, userName: user.name,),
       body: SafeArea(
         child: Container(
           padding: const EdgeInsets.only(
@@ -97,7 +99,6 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
             onRefresh: () => setUserInformation(),
             child: ListView(
               children: [
-                AlcanciaNavbar(username: user.name),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [

--- a/lib/src/screens/forgot_password/forgot_password.dart
+++ b/lib/src/screens/forgot_password/forgot_password.dart
@@ -127,6 +127,7 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
     if (_state.error != null) return Scaffold(body: SafeArea(child: Text(_state.error as String)));
 
     return Scaffold(
+      appBar: const AlcanciaToolbar(state: StateToolbar.logoLetters, logoHeight: 60, toolbarHeight: 70,),
       body: SafeArea(
         bottom: false,
         child: Form(
@@ -141,8 +142,7 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
               bottom: 28,
             ),
             children: [
-              const AlcanciaToolbar(state: StateToolbar.logoLetters, logoHeight: 60),
-              AlcanciaContainer(top: 40, child: Text('¡Hola!', style: txtTheme.headline1)),
+              AlcanciaContainer(child: Text('¡Hola!', style: txtTheme.headline1)),
               AlcanciaContainer(top: 8, child: Text('Vamos a recuperar tu contraseña', style: txtTheme.headline2)),
               AlcanciaContainer(
                 top: 16,

--- a/lib/src/screens/metamap/address_screen.dart
+++ b/lib/src/screens/metamap/address_screen.dart
@@ -92,6 +92,10 @@ class _AddressScreenState extends ConsumerState<AddressScreen> {
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: Scaffold(
+        appBar: AlcanciaToolbar(
+          state: StateToolbar.logoNoletters,
+          logoHeight: responsiveService.getHeightPixels(40, screenHeight),
+        ),
         body: SafeArea(
           bottom: false,
           child: Form(
@@ -100,14 +104,7 @@ class _AddressScreenState extends ConsumerState<AddressScreen> {
               padding: const EdgeInsets.only(left: 32.0, right: 32.0, bottom: 32.0),
               children: [
                 Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: AlcanciaToolbar(
-                    state: StateToolbar.logoNoletters,
-                    logoHeight: responsiveService.getHeightPixels(40, screenHeight),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 32.0, top: 8),
+                  padding: const EdgeInsets.only(bottom: 32.0, top: 24),
                   child: Center(
                     child: Text("Necesitamos saber más de ti 🤔",
                         style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold)),

--- a/lib/src/screens/success/success_screen.dart
+++ b/lib/src/screens/success/success_screen.dart
@@ -15,16 +15,19 @@ class SuccessScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final screenHeight = MediaQuery.of(context).size.height;
     return Scaffold(
+      appBar: AlcanciaToolbar(
+        toolbarHeight: responsiveService.getHeightPixels(90, screenHeight),
+        state: StateToolbar.logoLetters,
+        logoHeight: responsiveService.getHeightPixels(80, screenHeight),
+      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(32.0),
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              AlcanciaToolbar(
-                state: StateToolbar.logoLetters,
-                logoHeight: responsiveService.getHeightPixels(80, screenHeight),
-              ),
+              const Spacer(),
               Column(
                 children: [
                   SvgPicture.asset("lib/src/resources/images/confetti.svg"),
@@ -38,13 +41,15 @@ class SuccessScreen extends StatelessWidget {
                   ),
                 ],
               ),
+              const Spacer(),
               AlcanciaButton(
                   width: double.infinity,
                   height: responsiveService.getHeightPixels(64, screenHeight),
                   buttonText: "Entendido",
                   onPressed: () {
                     context.go("/");
-                  }),
+                  },
+              ),
             ],
           ),
         ),

--- a/lib/src/screens/swap/swap_screen.dart
+++ b/lib/src/screens/swap/swap_screen.dart
@@ -144,15 +144,15 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
         FocusManager.instance.primaryFocus?.unfocus();
       },
       child: Scaffold(
+        appBar: AlcanciaToolbar(
+          showBackButton: true,
+          state: StateToolbar.logoNoletters,
+          logoHeight: responsiveService.getHeightPixels(40, screenHeight),
+        ),
         body: SafeArea(
           child: SingleChildScrollView(
             child: Column(
               children: [
-                AlcanciaToolbar(
-                  state: StateToolbar.logoNoletters,
-                  logoHeight: responsiveService.getHeightPixels(40, screenHeight),
-                ),
-
                 // general container, sets padding
                 AlcanciaContainer(
                   top: 20,

--- a/lib/src/screens/withdraw/withdraw_screen.dart
+++ b/lib/src/screens/withdraw/withdraw_screen.dart
@@ -87,6 +87,11 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
     }
 
     return Scaffold(
+      appBar: const AlcanciaToolbar(
+        title: "Retiro de dinero",
+        state: StateToolbar.titleIcon,
+        logoHeight: 40,
+      ),
       body: SafeArea(
         child: Form(
           key: _formKey,
@@ -95,11 +100,6 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
           child: ListView(
             padding: const EdgeInsets.only(top: 10, left: 40, right: 40),
             children: [
-              const AlcanciaToolbar(
-                title: "Retiro de dinero",
-                state: StateToolbar.titleIcon,
-                logoHeight: 40,
-              ),
               const Text(
                 "¡Hola!",
                 style: TextStyle(fontSize: 35, fontWeight: FontWeight.w700),

--- a/lib/src/shared/components/alcancia_toolbar.dart
+++ b/lib/src/shared/components/alcancia_toolbar.dart
@@ -1,20 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:alcancia/src/shared/components/alcancia_components.dart';
+import 'package:go_router/go_router.dart';
 
 enum StateToolbar { logoNoletters, logoLetters, titleIcon, profileTitleIcon }
 
-class AlcanciaToolbar extends StatelessWidget {
+class AlcanciaToolbar extends StatelessWidget with PreferredSizeWidget {
   const AlcanciaToolbar({
     Key? key,
     this.title,
     required this.state,
     this.userName,
     required this.logoHeight,
+    this.showBackButton = false,
+    this.toolbarHeight = kToolbarHeight,
   }) : super(key: key);
 
   final String? title;
   final String? userName;
   final double logoHeight;
+  final bool showBackButton;
+  final double toolbarHeight;
   /*
   logo-noletters
   logo-letters
@@ -27,78 +32,86 @@ class AlcanciaToolbar extends StatelessWidget {
     var txtTheme = Theme.of(context).textTheme;
     switch (state) {
       case StateToolbar.logoNoletters:
-        return Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AlcanciaLogo(
-              height: logoHeight,
-            )
-          ],
+        return AppBar(
+          iconTheme: Theme.of(context).iconTheme,
+          toolbarHeight: toolbarHeight,
+          backgroundColor: Theme.of(context).backgroundColor,
+          elevation: 0,
+          scrolledUnderElevation: 0.3,
+          title:
+          AlcanciaLogo(
+            height: logoHeight,
+          ),
         );
       case StateToolbar.logoLetters:
-        return Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
+        return AppBar(
+          iconTheme: Theme.of(context).iconTheme,
+          toolbarHeight: toolbarHeight,
+          backgroundColor: Theme.of(context).backgroundColor,
+          elevation: 0,
+          scrolledUnderElevation: 0.3,
+          title:
             AlcanciaLogo(
               letters: true,
               height: logoHeight,
             ),
-          ],
         );
       case StateToolbar.titleIcon:
-        return Container(
-          padding: const EdgeInsets.only(top: 10, bottom: 10),
-          child: Stack(
-            children: [
-              Align(
-                alignment: Alignment.center,
-                child: Text(
-                  "$title",
-                  style: txtTheme.subtitle1,
-                ),
-              ),
-              Align(
-                alignment: Alignment.topRight,
-                child: Transform(
-                  transform: Matrix4.translationValues(0, -10, 0),
-                  child: AlcanciaLogo(
-                    height: logoHeight,
-                  ),
-                ),
-              ),
-            ],
+        return AppBar(
+          iconTheme: Theme.of(context).iconTheme,
+          toolbarHeight: toolbarHeight,
+          backgroundColor: Theme.of(context).backgroundColor,
+          elevation: 0,
+          scrolledUnderElevation: 0.3,
+          title: Text(
+            "$title",
+            style: txtTheme.subtitle1,
           ),
-        );
-      case StateToolbar.profileTitleIcon:
-        return Container(
-          padding: const EdgeInsets.only(bottom: 24),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Row(
-                children: [
-                  Image.asset(
-                    "lib/src/resources/images/profile.png",
-                    width: 38,
-                    height: 38,
-                  ),
-                  Padding(
-                    padding: EdgeInsets.only(left: 16),
-                    child: Text(
-                      "Hola, $userName",
-                      style: txtTheme.subtitle1,
-                    ),
-                  ),
-                ],
-              ),
-              AlcanciaLogo(
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 40.0),
+              child: AlcanciaLogo(
                 height: logoHeight,
               ),
-            ],
+            ),
+          ],
+        );
+      case StateToolbar.profileTitleIcon:
+        return AppBar(
+          iconTheme: Theme.of(context).iconTheme,
+          toolbarHeight: toolbarHeight,
+          backgroundColor: Theme.of(context).backgroundColor,
+          elevation: 0,
+          scrolledUnderElevation: 0.3,
+          leadingWidth: 60,
+          leading: Padding(
+            padding: const EdgeInsets.only(left: 16.0),
+            child: Image.asset(
+              "lib/src/resources/images/profile.png",
+              width: 38,
+              height: 38,
+            ),
           ),
+          title: Text(
+            "Hola, $userName",
+            style: txtTheme.subtitle1,
+          ),
+          centerTitle: false,
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 40.0),
+              child: AlcanciaLogo(
+                height: logoHeight,
+              ),
+            ),
+          ],
         );
       default:
         return const Text("Default");
     }
   }
+
+  @override
+  // TODO: implement preferredSize
+  Size get preferredSize => Size.fromHeight(toolbarHeight);
 }


### PR DESCRIPTION
## Summary
This automatically adds back button where pop is possible and keeps the bar on screen when scrolling.

## Requirements
N/A

## Type of change
- [ ] feature
- [ ] hotfix
- [ ] fix
- [ ] refactor
- [x] chore
- [ ] docs

## How to test?
Try to visit all screens in the app

## How has this been tested?
- [ ] App Bar should stay when scrolling down
- [ ] App Bar should show some elevation on scrolling
- [ ] Back button should show where context.pop() is available

## Screenshots
![image](https://user-images.githubusercontent.com/39177932/218284808-772ad9a3-5db0-424d-aa95-a962e6223899.png)
![image](https://user-images.githubusercontent.com/39177932/218284821-2a0c07ef-a3f9-4bf5-80da-5b7165eb74be.png)


## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?