### PR TITLE
Fix/dismiss keyboard

### DIFF
--- a/lib/src/screens/forgot_password/forgot_password.dart
+++ b/lib/src/screens/forgot_password/forgot_password.dart
@@ -333,14 +333,14 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
                     onPressed: _isButtonEnabled ? completeForgotPassword : null,
                   ),
                 ),
-              ),
-              if (_state.loading) const Scaffold(body: SafeArea(child: Center(child: CircularProgressIndicator()))),
-              if (_completePassState.error != null)
-                AlcanciaContainer(
-                  top: 16,
-                  child: Text(_completePassState.error as String, style: const TextStyle(color: Colors.red)),
-                )
-            ],
+                if (_state.loading) const Scaffold(body: SafeArea(child: Center(child: CircularProgressIndicator()))),
+                if (_completePassState.error != null)
+                  AlcanciaContainer(
+                    top: 16,
+                    child: Text(_completePassState.error as String, style: const TextStyle(color: Colors.red)),
+                  )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/screens/forgot_password/forgot_password.dart
+++ b/lib/src/screens/forgot_password/forgot_password.dart
@@ -126,211 +126,214 @@ class _ForgotPasswordState extends ConsumerState<ForgotPassword> {
     if (_state.loading) return const Scaffold(body: SafeArea(child: Center(child: CircularProgressIndicator())));
     if (_state.error != null) return Scaffold(body: SafeArea(child: Text(_state.error as String)));
 
-    return Scaffold(
-      appBar: const AlcanciaToolbar(state: StateToolbar.logoLetters, logoHeight: 60, toolbarHeight: 70,),
-      body: SafeArea(
-        bottom: false,
-        child: Form(
-          onChanged: () => setState(() => _isButtonEnabled = _formKey.currentState!.validate()),
-          key: _formKey,
-          autovalidateMode: AutovalidateMode.onUserInteraction,
-          child: ListView(
-            padding: const EdgeInsets.only(
-              top: 20,
-              left: 38,
-              right: 38,
-              bottom: 28,
-            ),
-            children: [
-              AlcanciaContainer(child: Text('¡Hola!', style: txtTheme.headline1)),
-              AlcanciaContainer(top: 8, child: Text('Vamos a recuperar tu contraseña', style: txtTheme.headline2)),
-              AlcanciaContainer(
-                top: 16,
-                child: Text(
-                  'Ingresa el código que enviamos a tu celular que termina en $_phoneNumEnding',
-                  style: txtTheme.bodyText1,
-                ),
+    return GestureDetector(
+      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+      child: Scaffold(
+        appBar: const AlcanciaToolbar(state: StateToolbar.logoLetters, logoHeight: 60, toolbarHeight: 70,),
+        body: SafeArea(
+          bottom: false,
+          child: Form(
+            onChanged: () => setState(() => _isButtonEnabled = _formKey.currentState!.validate()),
+            key: _formKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+            child: ListView(
+              padding: const EdgeInsets.only(
+                top: 20,
+                left: 38,
+                right: 38,
+                bottom: 28,
               ),
-              AlcanciaContainer(
-                top: 16,
-                child: LabeledTextFormField(
-                  controller: _verificationCodeControler,
-                  labelText: "Codigo secreto",
-                  validator: (value) => value == null || value == "" ? 'Field cannot be empty' : null,
-                  onChanged: (value) {
-                    setState(() {
-                      _verificationCode = value;
-                    });
-                  },
+              children: [
+                AlcanciaContainer(child: Text('¡Hola!', style: txtTheme.headline1)),
+                AlcanciaContainer(top: 8, child: Text('Vamos a recuperar tu contraseña', style: txtTheme.headline2)),
+                AlcanciaContainer(
+                  top: 16,
+                  child: Text(
+                    'Ingresa el código que enviamos a tu celular que termina en $_phoneNumEnding',
+                    style: txtTheme.bodyText1,
+                  ),
                 ),
-              ),
-              AlcanciaContainer(
-                top: 16,
-                child: StreamBuilder<int>(
-                    //TODO: Hacer reusable
-                    stream: timer.rawTime,
-                    initialData: 0,
-                    builder: (BuildContext ctx, AsyncSnapshot snapshot) {
-                      final value = snapshot.data;
-                      final displayTime = StopWatchTimer.getDisplayTime(value, hours: false, milliSecond: false);
-                      return Column(
-                        children: [
-                          Center(
-                            child: Container(
-                              decoration: ShapeDecoration(
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(100),
-                                  side: const BorderSide(color: alcanciaLightBlue),
+                AlcanciaContainer(
+                  top: 16,
+                  child: LabeledTextFormField(
+                    controller: _verificationCodeControler,
+                    labelText: "Codigo secreto",
+                    validator: (value) => value == null || value == "" ? 'Field cannot be empty' : null,
+                    onChanged: (value) {
+                      setState(() {
+                        _verificationCode = value;
+                      });
+                    },
+                  ),
+                ),
+                AlcanciaContainer(
+                  top: 16,
+                  child: StreamBuilder<int>(
+                      //TODO: Hacer reusable
+                      stream: timer.rawTime,
+                      initialData: 0,
+                      builder: (BuildContext ctx, AsyncSnapshot snapshot) {
+                        final value = snapshot.data;
+                        final displayTime = StopWatchTimer.getDisplayTime(value, hours: false, milliSecond: false);
+                        return Column(
+                          children: [
+                            Center(
+                              child: Container(
+                                decoration: ShapeDecoration(
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(100),
+                                    side: const BorderSide(color: alcanciaLightBlue),
+                                  ),
                                 ),
-                              ),
-                              child: Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    const Icon(
-                                      Icons.timer_sharp,
-                                      color: alcanciaLightBlue,
-                                    ),
-                                    Text(
-                                      displayTime,
-                                      style: const TextStyle(color: alcanciaLightBlue),
-                                    ),
-                                  ],
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      const Icon(
+                                        Icons.timer_sharp,
+                                        color: alcanciaLightBlue,
+                                      ),
+                                      Text(
+                                        displayTime,
+                                        style: const TextStyle(color: alcanciaLightBlue),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ),
-                          ),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              const Text("¿No recibiste el código?"),
-                              TextButton(
-                                onPressed: value <= 0
-                                    ? () async {
-                                        await forgotPassword();
-                                        timer.onResetTimer();
-                                        timer.onStartTimer();
-                                      }
-                                    : null,
-                                style: TextButton.styleFrom(foregroundColor: alcanciaLightBlue),
-                                child: const Text(
-                                  "Reenviar",
-                                  style: TextStyle(decoration: TextDecoration.underline, fontWeight: FontWeight.bold),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const Text("¿No recibiste el código?"),
+                                TextButton(
+                                  onPressed: value <= 0
+                                      ? () async {
+                                          await forgotPassword();
+                                          timer.onResetTimer();
+                                          timer.onStartTimer();
+                                        }
+                                      : null,
+                                  style: TextButton.styleFrom(foregroundColor: alcanciaLightBlue),
+                                  child: const Text(
+                                    "Reenviar",
+                                    style: TextStyle(decoration: TextDecoration.underline, fontWeight: FontWeight.bold),
+                                  ),
                                 ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      );
+                              ],
+                            ),
+                          ],
+                        );
+                      }),
+                ),
+                AlcanciaContainer(
+                  top: 16,
+                  child: LabeledTextFormField(
+                    controller: _newPasswordController,
+                    labelText: "Nueva contraseña",
+                    obscure: obscurePassword,
+                    validator: (value) => value == null || value == "" ? 'Field cannot be empty' : null,
+                    onChanged: (value) => setState(() {
+                      _newPassword = value;
                     }),
-              ),
-              AlcanciaContainer(
-                top: 16,
-                child: LabeledTextFormField(
-                  controller: _newPasswordController,
-                  labelText: "Nueva contraseña",
-                  obscure: obscurePassword,
-                  validator: (value) => value == null || value == "" ? 'Field cannot be empty' : null,
-                  onChanged: (value) => setState(() {
-                    _newPassword = value;
-                  }),
-                  suffixIcon: GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        obscurePassword = !obscurePassword;
-                      });
-                    },
-                    child: Icon(obscurePassword ? CupertinoIcons.eye : CupertinoIcons.eye_fill),
+                    suffixIcon: GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          obscurePassword = !obscurePassword;
+                        });
+                      },
+                      child: Icon(obscurePassword ? CupertinoIcons.eye : CupertinoIcons.eye_fill),
+                    ),
                   ),
                 ),
-              ),
-              AlcanciaContainer(
-                top: 16,
-                child: LabeledTextFormField(
-                  controller: _confirmPasswordController,
-                  labelText: "Confirma tu nueva contraseña",
-                  obscure: obscureConfirmPassword,
-                  validator: (value) {
-                    if (value == null || value.isEmpty) return 'Field should not empty';
-                    if (value != _newPassword) return 'Password do not match';
-                    return null;
-                  },
-                  suffixIcon: GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        obscureConfirmPassword = !obscureConfirmPassword;
-                      });
+                AlcanciaContainer(
+                  top: 16,
+                  child: LabeledTextFormField(
+                    controller: _confirmPasswordController,
+                    labelText: "Confirma tu nueva contraseña",
+                    obscure: obscureConfirmPassword,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) return 'Field should not empty';
+                      if (value != _newPassword) return 'Password do not match';
+                      return null;
                     },
-                    child: Icon(obscureConfirmPassword ? CupertinoIcons.eye : CupertinoIcons.eye_fill),
+                    suffixIcon: GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          obscureConfirmPassword = !obscureConfirmPassword;
+                        });
+                      },
+                      child: Icon(obscureConfirmPassword ? CupertinoIcons.eye : CupertinoIcons.eye_fill),
+                    ),
                   ),
                 ),
-              ),
-              AlcanciaContainer(
-                top: 10,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('Tu contraseña debe tener al menos:\n', style: txtTheme.bodyText1),
-                    Row(
-                      children: [
-                        _newPassword.hasUpperCase()
-                            ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
-                            : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
-                        const Padding(padding: EdgeInsets.only(left: 10), child: Text('Una letra mayúscula'))
-                      ],
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 8),
-                      child: Row(
+                AlcanciaContainer(
+                  top: 10,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Tu contraseña debe tener al menos:\n', style: txtTheme.bodyText1),
+                      Row(
                         children: [
-                          _newPassword.hasLowerCase()
+                          _newPassword.hasUpperCase()
                               ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
                               : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
-                          const Padding(padding: EdgeInsets.only(left: 10), child: Text('Una letra minuscula'))
+                          const Padding(padding: EdgeInsets.only(left: 10), child: Text('Una letra mayúscula'))
                         ],
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 8.0),
-                      child: Row(
-                        children: [
-                          _newPassword.hasDigits()
-                              ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
-                              : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
-                          const Padding(padding: EdgeInsets.only(left: 10), child: Text('Un número'))
-                        ],
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: Row(
+                          children: [
+                            _newPassword.hasLowerCase()
+                                ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
+                                : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
+                            const Padding(padding: EdgeInsets.only(left: 10), child: Text('Una letra minuscula'))
+                          ],
+                        ),
                       ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 8.0),
-                      child: Row(
-                        children: [
-                          _newPassword.hasSpecialChar()
-                              ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
-                              : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
-                          const Padding(
-                            padding: EdgeInsets.only(left: 10),
-                            child: Text('Un caracter especial [!@#\$%^&*(),.?":{}|<>]'),
-                          )
-                        ],
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: Row(
+                          children: [
+                            _newPassword.hasDigits()
+                                ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
+                                : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
+                            const Padding(padding: EdgeInsets.only(left: 10), child: Text('Un número'))
+                          ],
+                        ),
                       ),
-                    )
-                  ],
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8.0),
+                        child: Row(
+                          children: [
+                            _newPassword.hasSpecialChar()
+                                ? SvgPicture.asset('lib/src/resources/images/icon_check.svg', height: 20)
+                                : SvgPicture.asset('lib/src/resources/images/icon_cross.svg', height: 20),
+                            const Padding(
+                              padding: EdgeInsets.only(left: 10),
+                              child: Text('Un caracter especial [!@#\$%^&*(),.?":{}|<>]'),
+                            )
+                          ],
+                        ),
+                      )
+                    ],
+                  ),
                 ),
-              ),
-              AlcanciaContainer(
-                top: 50,
-                child: AlcanciaButton(
-                  width: double.infinity,
-                  height: 64,
-                  buttonText: "Siguiente",
-                  onPressed: _isButtonEnabled ? completeForgotPassword : null,
+                AlcanciaContainer(
+                  top: 50,
+                  child: AlcanciaButton(
+                    width: double.infinity,
+                    height: 64,
+                    buttonText: "Siguiente",
+                    onPressed: _isButtonEnabled ? completeForgotPassword : null,
+                  ),
                 ),
-              ),
-              if (_state.loading) const Scaffold(body: SafeArea(child: Center(child: CircularProgressIndicator()))),
-              if (_completePassState.error != null) AlcanciaContainer(top: 16, child: Text(_completePassState.error as String, style: TextStyle(color: Colors.red),))
-            ],
+                if (_state.loading) const Scaffold(body: SafeArea(child: Center(child: CircularProgressIndicator()))),
+                if (_completePassState.error != null) AlcanciaContainer(top: 16, child: Text(_completePassState.error as String, style: TextStyle(color: Colors.red),))
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/screens/withdraw/withdraw_screen.dart
+++ b/lib/src/screens/withdraw/withdraw_screen.dart
@@ -86,190 +86,193 @@ class _WithdrawScreenState extends ConsumerState<WithdrawScreen> {
       return Scaffold(body: SafeArea(child: Center(child: Text(_error))));
     }
 
-    return Scaffold(
-      appBar: const AlcanciaToolbar(
-        title: "Retiro de dinero",
-        state: StateToolbar.titleIcon,
-        logoHeight: 40,
-      ),
-      body: SafeArea(
-        child: Form(
-          key: _formKey,
-          autovalidateMode: AutovalidateMode.always,
-          onChanged: () => setState(() => _enableButton = _formKey.currentState!.validate()),
-          child: ListView(
-            padding: const EdgeInsets.only(top: 10, left: 40, right: 40),
-            children: [
-              const Text(
-                "¡Hola!",
-                style: TextStyle(fontSize: 35, fontWeight: FontWeight.w700),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 12),
-                child: Text(
-                  "Completa la siguiente información para realizar el retiro de tu dinero:",
-                  style: txtTheme.bodyText1,
+    return GestureDetector(
+      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+      child: Scaffold(
+        appBar: const AlcanciaToolbar(
+          title: "Retiro de dinero",
+          state: StateToolbar.titleIcon,
+          logoHeight: 40,
+        ),
+        body: SafeArea(
+          child: Form(
+            key: _formKey,
+            autovalidateMode: AutovalidateMode.always,
+            onChanged: () => setState(() => _enableButton = _formKey.currentState!.validate()),
+            child: ListView(
+              padding: const EdgeInsets.only(top: 10, left: 40, right: 40),
+              children: [
+                const Text(
+                  "¡Hola!",
+                  style: TextStyle(fontSize: 35, fontWeight: FontWeight.w700),
                 ),
-              ),
-              Container(
-                padding: const EdgeInsets.only(top: 20),
-                child: Column(
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Text(
+                    "Completa la siguiente información para realizar el retiro de tu dinero:",
+                    style: txtTheme.bodyText1,
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.only(top: 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        "País",
+                        style: txtTheme.bodyText1,
+                      ),
+                      AlcanciaDropdown(
+                        itemsAlignment: MainAxisAlignment.start,
+                        dropdownItems: countries,
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).inputDecorationTheme.fillColor,
+                          borderRadius: BorderRadius.circular(7),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      "País",
+                      "Moneda",
                       style: txtTheme.bodyText1,
                     ),
                     AlcanciaDropdown(
                       itemsAlignment: MainAxisAlignment.start,
-                      dropdownItems: countries,
+                      dropdownItems: sourceCurrencies,
                       decoration: BoxDecoration(
                         color: Theme.of(context).inputDecorationTheme.fillColor,
                         borderRadius: BorderRadius.circular(7),
                       ),
+                      onChanged: (value) {
+                        setState(() {
+                          sourceCurrency = value;
+                        });
+                      },
                     ),
                   ],
                 ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    "Moneda",
-                    style: txtTheme.bodyText1,
-                  ),
-                  AlcanciaDropdown(
-                    itemsAlignment: MainAxisAlignment.start,
-                    dropdownItems: sourceCurrencies,
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).inputDecorationTheme.fillColor,
-                      borderRadius: BorderRadius.circular(7),
-                    ),
-                    onChanged: (value) {
-                      setState(() {
-                        sourceCurrency = value;
-                      });
-                    },
-                  ),
-                ],
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              LabeledTextFormField(
-                controller: _clabeTextController,
-                labelText: "Número CLABE",
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                inputType: TextInputType.number,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return appLoc.errorRequiredField;
-                  } else if (value.length != 18) {
-                    return "La CLABE debe consistir de 18 dígitos";
-                  }
-                },
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              LabeledTextFormField(
-                controller: _amountTextController,
-                labelText: "Monto de retiro",
-                inputType: TextInputType.number,
-                inputFormatters: [DecimalTextInputFormatter(decimalRange: 2)],
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return appLoc.errorRequiredField;
-                  } else if (balance < double.parse(value)) {
-                    return "No cuentas con el balance necesario";
-                  }
-                  return null;
-                },
-                onChanged: (value) => setState(() {
-                  targetAmount = value.isNotEmpty
-                      ? double.parse(_amountTextController.text) /
-                          (sourceCurrency == "USDC" ? suarmiUSDCExchange : suarmiCELOExchange)
-                      : 0;
-                  _targetTextController.text = targetAmount.toStringAsFixed(3);
-                }),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              Text("Balance disponible: \$${balance.toStringAsFixed(2)}"),
-              const SizedBox(
-                height: 10,
-              ),
-              LabeledTextFormField(
-                controller: _targetTextController,
-                labelText: "Monto en MXN",
-                inputType: TextInputType.number,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                enabled: false,
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 24),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    if (_loadingButton) ...[
-                      const CircularProgressIndicator(),
-                    ] else ...[
-                      AlcanciaButton(
-                        buttonText: "Siguiente",
-                        onPressed: _enableButton
-                            ? () async {
-                                setState(() {
-                                  _loadingButton = true;
-                                });
-                                final orderInput = {
-                                  "orderInput": {
-                                    "from_amount": _amountTextController.text,
-                                    "type": "WITHDRAW",
-                                    "from_currency": sourceCurrency == 'USDC' ? 'aPolUSDC' : 'mcUSD',
-                                    "network": sourceCurrency == "USDC" ? "MATIC" : "CELO",
-                                    "to_amount": targetAmount.toString(),
-                                    "to_currency": "MXN",
-                                    "bank_account": _clabeTextController.text,
-                                  }
-                                };
-                                try {
-                                  final order = await controller.sendSuarmiOrder(orderInput);
-                                  context.go("/success", extra: "¡Orden de retiro enviada!");
-                                } catch (e) {
+                const SizedBox(
+                  height: 10,
+                ),
+                LabeledTextFormField(
+                  controller: _clabeTextController,
+                  labelText: "Número CLABE",
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  inputType: TextInputType.number,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return appLoc.errorRequiredField;
+                    } else if (value.length != 18) {
+                      return "La CLABE debe consistir de 18 dígitos";
+                    }
+                  },
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                LabeledTextFormField(
+                  controller: _amountTextController,
+                  labelText: "Monto de retiro",
+                  inputType: TextInputType.number,
+                  inputFormatters: [DecimalTextInputFormatter(decimalRange: 2)],
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return appLoc.errorRequiredField;
+                    } else if (balance < double.parse(value)) {
+                      return "No cuentas con el balance necesario";
+                    }
+                    return null;
+                  },
+                  onChanged: (value) => setState(() {
+                    targetAmount = value.isNotEmpty
+                        ? double.parse(_amountTextController.text) /
+                            (sourceCurrency == "USDC" ? suarmiUSDCExchange : suarmiCELOExchange)
+                        : 0;
+                    _targetTextController.text = targetAmount.toStringAsFixed(3);
+                  }),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                Text("Balance disponible: \$${balance.toStringAsFixed(2)}"),
+                const SizedBox(
+                  height: 10,
+                ),
+                LabeledTextFormField(
+                  controller: _targetTextController,
+                  labelText: "Monto en MXN",
+                  inputType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  enabled: false,
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 24),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      if (_loadingButton) ...[
+                        const CircularProgressIndicator(),
+                      ] else ...[
+                        AlcanciaButton(
+                          buttonText: "Siguiente",
+                          onPressed: _enableButton
+                              ? () async {
                                   setState(() {
-                                    _orderError = e.toString();
+                                    _loadingButton = true;
+                                  });
+                                  final orderInput = {
+                                    "orderInput": {
+                                      "from_amount": _amountTextController.text,
+                                      "type": "WITHDRAW",
+                                      "from_currency": sourceCurrency == 'USDC' ? 'aPolUSDC' : 'mcUSD',
+                                      "network": sourceCurrency == "USDC" ? "MATIC" : "CELO",
+                                      "to_amount": targetAmount.toString(),
+                                      "to_currency": "MXN",
+                                      "bank_account": _clabeTextController.text,
+                                    }
+                                  };
+                                  try {
+                                    final order = await controller.sendSuarmiOrder(orderInput);
+                                    context.go("/success", extra: "¡Orden de retiro enviada!");
+                                  } catch (e) {
+                                    setState(() {
+                                      _orderError = e.toString();
+                                    });
+                                  }
+                                  setState(() {
+                                    _loadingButton = false;
                                   });
                                 }
-                                setState(() {
-                                  _loadingButton = false;
-                                });
-                              }
-                            : null,
-                        color: alcanciaLightBlue,
-                        width: 308,
-                        height: 64,
-                      ),
-                    ],
-                    if (_orderError.isNotEmpty) ...[
-                      Padding(
-                        padding: EdgeInsets.all(8.0),
-                        child: Text(
-                          _orderError,
-                          style: TextStyle(color: Colors.red),
+                              : null,
+                          color: alcanciaLightBlue,
+                          width: 308,
+                          height: 64,
                         ),
-                      ),
-                    ]
-                  ],
+                      ],
+                      if (_orderError.isNotEmpty) ...[
+                        Padding(
+                          padding: EdgeInsets.all(8.0),
+                          child: Text(
+                            _orderError,
+                            style: TextStyle(color: Colors.red),
+                          ),
+                        ),
+                      ]
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
Adds the tap gesture in forgot password and withdraw screens to dismiss the on-screen keyboard

## Requirements
N/A

## Type of change
- [ ] feature
- [ ] hotfix
- [x] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
Go to forgot password screen, tap a textfield to start inputting text with the on-screen keyboard (cmd+k for iOS simulator) and tap anywhere else on the screen to dismiss it. Same thing with withdraw screen.

## How has this been tested?
^^^

## Screenshots
N/A

## Checklist (for the reviewer)

- [ ] Does the code compile without errors or warnings?
- [ ] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?