### PR TITLE
Mostrar detalles de la transferencia. 1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/lib/src/features/transaction-detail/presentation/transaction_detail.dart
+++ b/lib/src/features/transaction-detail/presentation/transaction_detail.dart
@@ -80,28 +80,28 @@ class TransactionDetail extends ConsumerWidget {
                     leftText: appLoc.labelStatus,
                     rightIcon: txn.iconForTxnStatus(user.id),
                   ),
-                  TransactionDetailItem(
-                    leftText: appLoc.labelClearedDate,
-                    rightText: txn.clearedDate?.formattedLocalString(),
-                  ),
-                  TransactionDetailItem(
-                    leftText: appLoc.labelNewBalance,
-                    rightText: (txn.newBalance == null)
-                        ? ''
-                        : '\$${txn.newBalance?.toStringAsFixed(2)}',
-                  ),
-                  TransactionDetailItem(
-                    leftText: appLoc.labelConversionRate,
-                    rightText: txn.conversionRate?.toStringAsFixed(2),
-                  ),
-                  TransactionDetailItem(
-                    leftText: appLoc.labelpaymentGatewayID,
-                    rightText: txn.paymentGatewayID?.toString(),
-                  ),
-                  TransactionDetailItem(
-                    leftText: appLoc.labelUserID,
-                    rightText: txn.userID?.toString(),
-                  ),
+                  if (txn.status == "PENDING") ...[
+                    TransactionDetailItem(
+                      leftText: appLoc.labelClearedDate,
+                      rightText: txn.clearedDate?.formattedLocalString(),
+                    ),
+                    TransactionDetailItem(
+                      leftText: appLoc.labelNewBalance,
+                      rightText: (txn.newBalance == null)
+                          ? ''
+                          : '\$${txn.newBalance?.toStringAsFixed(2)}',
+                    ),
+                    TransactionDetailItem(
+                      leftText: appLoc.labelConversionRate,
+                      rightText: txn.conversionRate?.toStringAsFixed(2),
+                    ),
+                    TransactionDetailItem(
+                      leftText: appLoc.labelTransMethod,
+                      rightText: (txn.method == "null" || txn.method!.isEmpty)
+                          ? ''
+                          : txn.method.toString(),
+                    ),
+                  ],
                   Padding(
                     padding: const EdgeInsets.only(top: 20),
                     child: SizedBox(

--- a/lib/src/features/transaction-detail/presentation/transaction_detail.dart
+++ b/lib/src/features/transaction-detail/presentation/transaction_detail.dart
@@ -26,9 +26,11 @@ class TransactionDetail extends ConsumerWidget {
             padding: const EdgeInsets.all(24),
             child: Container(
               padding: const EdgeInsets.all(18),
-              height: 430,
+              height: 630,
               decoration: BoxDecoration(
-                color: ctx.brightness == Brightness.dark ? alcanciaCardDark2 : alcanciaCardLight2,
+                color: ctx.brightness == Brightness.dark
+                    ? alcanciaCardDark2
+                    : alcanciaCardLight2,
                 borderRadius: const BorderRadius.all(
                   Radius.circular(11),
                 ),
@@ -52,14 +54,15 @@ class TransactionDetail extends ConsumerWidget {
                   ),
                   TransactionDetailItem(
                     leftText: appLoc.labelTransactionId,
-                    rightText: txn.transactionID.substring(0, txn.transactionID.indexOf('-')),
+                    rightText: txn.transactionID
+                        .substring(0, txn.transactionID.indexOf('-')),
                   ),
-                  if (txn.type == TransactionType.deposit) ... [
+                  if (txn.type == TransactionType.deposit) ...[
                     TransactionDetailItem(
                       leftText: appLoc.labelDepositValue,
                       rightText: '\$${txn.sourceAmount?.toStringAsFixed(2)}',
                     ),
-                  ] else if (txn.type == TransactionType.withdraw) ... [
+                  ] else if (txn.type == TransactionType.withdraw) ...[
                     TransactionDetailItem(
                       leftText: appLoc.labelWithdrawalValue,
                       rightText: '\$${txn.sourceAmount?.toStringAsFixed(2)}',
@@ -76,6 +79,28 @@ class TransactionDetail extends ConsumerWidget {
                   TransactionDetailItem(
                     leftText: appLoc.labelStatus,
                     rightIcon: txn.iconForTxnStatus(user.id),
+                  ),
+                  TransactionDetailItem(
+                    leftText: appLoc.labelClearedDate,
+                    rightText: txn.clearedDate?.formattedLocalString(),
+                  ),
+                  TransactionDetailItem(
+                    leftText: appLoc.labelNewBalance,
+                    rightText: (txn.newBalance == null)
+                        ? ''
+                        : '\$${txn.newBalance?.toStringAsFixed(2)}',
+                  ),
+                  TransactionDetailItem(
+                    leftText: appLoc.labelConversionRate,
+                    rightText: txn.conversionRate?.toStringAsFixed(2),
+                  ),
+                  TransactionDetailItem(
+                    leftText: appLoc.labelpaymentGatewayID,
+                    rightText: txn.paymentGatewayID?.toString(),
+                  ),
+                  TransactionDetailItem(
+                    leftText: appLoc.labelUserID,
+                    rightText: txn.userID?.toString(),
                   ),
                   Padding(
                     padding: const EdgeInsets.only(top: 20),

--- a/lib/src/features/transaction-detail/presentation/transaction_detail.dart
+++ b/lib/src/features/transaction-detail/presentation/transaction_detail.dart
@@ -80,7 +80,7 @@ class TransactionDetail extends ConsumerWidget {
                     leftText: appLoc.labelStatus,
                     rightIcon: txn.iconForTxnStatus(user.id),
                   ),
-                  if (txn.status == "PENDING") ...[
+                  if (txn.status == "PENDING" && txn.provider == "SUARMI") ...[
                     TransactionDetailItem(
                       leftText: appLoc.labelClearedDate,
                       rightText: txn.clearedDate?.formattedLocalString(),
@@ -100,6 +100,10 @@ class TransactionDetail extends ConsumerWidget {
                       rightText: (txn.method == "null" || txn.method!.isEmpty)
                           ? ''
                           : txn.method.toString(),
+                    ),
+                    TransactionDetailItem(
+                      leftText: appLoc.labelTransProvider,
+                      rightText: txn.provider?.toString(),
                     ),
                   ],
                   Padding(

--- a/lib/src/resources/l10n/app_en.arb
+++ b/lib/src/resources/l10n/app_en.arb
@@ -208,5 +208,6 @@
 	"labelNewBalance": "New Balance",
 	"labelConversionRate": "Conversion Rate",
 	"labelpaymentGatewayID": "Payment Gateway ID",
-	"labelUserID": "User ID"
+	"labelUserID": "User ID",
+	"labelTransMethod": "Method"
 }

--- a/lib/src/resources/l10n/app_en.arb
+++ b/lib/src/resources/l10n/app_en.arb
@@ -202,5 +202,11 @@
 	"labelNetwork": "Network",
 	"labelCoin": "Coin",
 	"alertAddressCopied": "Address copied",
-	"alertCopied": "Copied"
+	"alertCopied": "Copied",
+	"labelReceiverId": "Receiver ID",
+	"labelClearedDate": "Cleared date",
+	"labelNewBalance": "New Balance",
+	"labelConversionRate": "Conversion Rate",
+	"labelpaymentGatewayID": "Payment Gateway ID",
+	"labelUserID": "User ID"
 }

--- a/lib/src/resources/l10n/app_en.arb
+++ b/lib/src/resources/l10n/app_en.arb
@@ -209,5 +209,6 @@
 	"labelConversionRate": "Conversion Rate",
 	"labelpaymentGatewayID": "Payment Gateway ID",
 	"labelUserID": "User ID",
-	"labelTransMethod": "Method"
+	"labelTransMethod": "Method",
+	"labelTransProvider": "Transaction provider"
 }

--- a/lib/src/resources/l10n/app_es.arb
+++ b/lib/src/resources/l10n/app_es.arb
@@ -291,5 +291,6 @@
 	"labelConversionRate": "Tasa de conversión",
 	"labelpaymentGatewayID": "ID del Payment Gateway",
 	"labelUserID": "User ID",
-	"labelTransMethod": "Método"
+	"labelTransMethod": "Método",
+	"labelTransProvider": "Proveedor transaccional"
 }

--- a/lib/src/resources/l10n/app_es.arb
+++ b/lib/src/resources/l10n/app_es.arb
@@ -290,5 +290,6 @@
 	"labelNewBalance": "Nuevo balance",
 	"labelConversionRate": "Tasa de conversión",
 	"labelpaymentGatewayID": "ID del Payment Gateway",
-	"labelUserID": "User ID"
+	"labelUserID": "User ID",
+	"labelTransMethod": "Método"
 }

--- a/lib/src/resources/l10n/app_es.arb
+++ b/lib/src/resources/l10n/app_es.arb
@@ -284,6 +284,11 @@
 	"labelNetwork": "Red",
 	"labelCoin": "Moneda",
 	"alertAddressCopied": "Dirección copiada",
-	"alertCopied": "Copiad@"
-
+	"alertCopied": "Copiad@",
+	"labelReceiverId": "ID del receptor",
+	"labelClearedDate": "Fecha de liquidación",
+	"labelNewBalance": "Nuevo balance",
+	"labelConversionRate": "Tasa de conversión",
+	"labelpaymentGatewayID": "ID del Payment Gateway",
+	"labelUserID": "User ID"
 }

--- a/lib/src/shared/graphql/queries/transactions_query.dart
+++ b/lib/src/shared/graphql/queries/transactions_query.dart
@@ -17,6 +17,7 @@ const String transactionsQuery = """
           newBalance,
           conversionRate,
           method,
+          provider,
       }
     }
   }

--- a/lib/src/shared/graphql/queries/transactions_query.dart
+++ b/lib/src/shared/graphql/queries/transactions_query.dart
@@ -16,8 +16,6 @@ const String transactionsQuery = """
           clearedDate,
           newBalance,
           conversionRate,
-          paymentGatewayID,
-          userID,
           method,
       }
     }

--- a/lib/src/shared/graphql/queries/transactions_query.dart
+++ b/lib/src/shared/graphql/queries/transactions_query.dart
@@ -13,6 +13,12 @@ const String transactionsQuery = """
           status,
           senderId,
           receiverId,
+          clearedDate,
+          newBalance,
+          conversionRate,
+          paymentGatewayID,
+          userID,
+          method,
       }
     }
   }

--- a/lib/src/shared/models/transaction_model.dart
+++ b/lib/src/shared/models/transaction_model.dart
@@ -19,6 +19,7 @@ class Transaction {
   double? newBalance;
   double? conversionRate;
   String? method;
+  String? provider;
 
   Transaction(
       {required this.transactionID,
@@ -34,7 +35,8 @@ class Transaction {
       required this.clearedDate,
       required this.newBalance,
       required this.conversionRate,
-      required this.method});
+      required this.method,
+      required this.provider});
 
   factory Transaction.fromJson(Map<String, dynamic> json) {
     final targetAsset = json["targetAsset"];
@@ -74,7 +76,8 @@ class Transaction {
         clearedDate: clearedDate,
         newBalance: double.tryParse(json["newBalance"].toString()),
         conversionRate: double.tryParse(json["conversionRate"].toString()),
-        method: json["method"]);
+        method: json["method"],
+        provider: json["provider"]);
   }
 }
 

--- a/lib/src/shared/models/transaction_model.dart
+++ b/lib/src/shared/models/transaction_model.dart
@@ -15,49 +15,98 @@ class Transaction {
   String status;
   String? senderId;
   String? receiverId;
+  DateTime? clearedDate;
+  double? newBalance;
+  double? conversionRate;
+  String? paymentGatewayID;
+  String? userID;
+  String? method;
 
-  Transaction({
-    required this.transactionID,
-    required this.createdAt,
-    required this.sourceAmount,
-    required this.sourceAsset,
-    required this.targetAsset,
-    required this.amount,
-    required this.type,
-    required this.status,
-    required this.senderId,
-    required this.receiverId,
-  });
+  Transaction(
+      {required this.transactionID,
+      required this.createdAt,
+      required this.sourceAmount,
+      required this.sourceAsset,
+      required this.targetAsset,
+      required this.amount,
+      required this.type,
+      required this.status,
+      required this.senderId,
+      required this.receiverId,
+      required this.clearedDate,
+      required this.newBalance,
+      required this.conversionRate,
+      required this.paymentGatewayID,
+      required this.userID,
+      required this.method});
 
   factory Transaction.fromJson(Map<String, dynamic> json) {
     final targetAsset = json["targetAsset"];
     final sourceAsset = json["sourceAsset"];
     final createdAt = DateTime.parse(json["createdAt"]);
+    DateTime? clearedDate = null;
+    String? clearedDateString = json["clearedDate"];
+    if (clearedDateString != null) {
+      clearedDate = DateTime.tryParse(clearedDateString);
+    } else {
+      clearedDate = null;
+    }
+    if (clearedDateString != null) {}
     return Transaction(
         transactionID: json["id"] as String,
         createdAt: createdAt,
         sourceAmount: double.tryParse(json["sourceAmount"].toString()),
-        sourceAsset:
-            CurrencyAsset.values.firstWhereOrNull((e) => e.actualAsset.toLowerCase() == sourceAsset.toString().toLowerCase())?.shownAsset ?? sourceAsset,
-        targetAsset:
-            CurrencyAsset.values.firstWhereOrNull((e) => e.actualAsset.toLowerCase() == targetAsset.toString().toLowerCase())?.shownAsset ?? targetAsset,
+        sourceAsset: CurrencyAsset.values
+                .firstWhereOrNull((e) =>
+                    e.actualAsset.toLowerCase() ==
+                    sourceAsset.toString().toLowerCase())
+                ?.shownAsset ??
+            sourceAsset,
+        targetAsset: CurrencyAsset.values
+                .firstWhereOrNull((e) =>
+                    e.actualAsset.toLowerCase() ==
+                    targetAsset.toString().toLowerCase())
+                ?.shownAsset ??
+            targetAsset,
         amount: double.parse(json["amount"].toString()),
-        type: TransactionType.values.firstWhere((e) => e.name.toUpperCase() == json["type"], orElse: () => TransactionType.unknown),
+        type: TransactionType.values.firstWhere(
+            (e) => e.name.toUpperCase() == json["type"],
+            orElse: () => TransactionType.unknown),
         status: json["status"] as String,
         senderId: json["senderId"],
         receiverId: json["receiverId"],
-    );
+        clearedDate: clearedDate,
+        newBalance: double.tryParse(json["newBalance"].toString()),
+        conversionRate: double.tryParse(json["conversionRate"].toString()),
+        paymentGatewayID: json["paymentGatewayID"],
+        userID: json["userID"],
+        method: json["method"]);
   }
 }
 
 extension StatusIcon on Transaction {
   Widget iconForTxnStatus(String currentUserId) {
-    if (status == "PENDING") return SvgPicture.asset("lib/src/resources/images/pending.svg", width: 24,);
+    if (status == "PENDING")
+      return SvgPicture.asset(
+        "lib/src/resources/images/pending.svg",
+        width: 24,
+      );
     if (status == "COMPLETED") {
-      if (type == TransactionType.deposit || receiverId == currentUserId) return SvgPicture.asset("lib/src/resources/images/deposit.svg", width: 24,);
-      if (type == TransactionType.withdraw || senderId == currentUserId) return SvgPicture.asset("lib/src/resources/images/withdrawal.svg", width: 24,);
+      if (type == TransactionType.deposit || receiverId == currentUserId)
+        return SvgPicture.asset(
+          "lib/src/resources/images/deposit.svg",
+          width: 24,
+        );
+      if (type == TransactionType.withdraw || senderId == currentUserId)
+        return SvgPicture.asset(
+          "lib/src/resources/images/withdrawal.svg",
+          width: 24,
+        );
     }
     // FAILED or EXPIRED
-    return SvgPicture.asset("lib/src/resources/images/failed.svg", width: 24,);
+    return SvgPicture.asset(
+      "lib/src/resources/images/failed.svg",
+      width: 24,
+    );
   }
 }

--- a/lib/src/shared/models/transaction_model.dart
+++ b/lib/src/shared/models/transaction_model.dart
@@ -18,8 +18,6 @@ class Transaction {
   DateTime? clearedDate;
   double? newBalance;
   double? conversionRate;
-  String? paymentGatewayID;
-  String? userID;
   String? method;
 
   Transaction(
@@ -36,8 +34,6 @@ class Transaction {
       required this.clearedDate,
       required this.newBalance,
       required this.conversionRate,
-      required this.paymentGatewayID,
-      required this.userID,
       required this.method});
 
   factory Transaction.fromJson(Map<String, dynamic> json) {
@@ -78,8 +74,6 @@ class Transaction {
         clearedDate: clearedDate,
         newBalance: double.tryParse(json["newBalance"].toString()),
         conversionRate: double.tryParse(json["conversionRate"].toString()),
-        paymentGatewayID: json["paymentGatewayID"],
-        userID: json["userID"],
         method: json["method"]);
   }
 }

--- a/lib/src/shared/services/transactions_service.dart
+++ b/lib/src/shared/services/transactions_service.dart
@@ -27,6 +27,7 @@ class TransactionsService {
   }
 
   List<Transaction> getTransactionsFromJson(Map<String, dynamic> json) {
+    print(json);
     var items = json['items'];
     if (items == null) {
       return <Transaction>[];

--- a/lib/src/shared/services/transactions_service.dart
+++ b/lib/src/shared/services/transactions_service.dart
@@ -27,7 +27,6 @@ class TransactionsService {
   }
 
   List<Transaction> getTransactionsFromJson(Map<String, dynamic> json) {
-    print(json);
     var items = json['items'];
     if (items == null) {
       return <Transaction>[];


### PR DESCRIPTION
## Summary
Se añade nivel de detalle a pantalla detalle de transacción.

## Requirements
Se requiere extender los detalles de la transaccion en la pantalla transaction_detail
Se extiende los campos de consulta del servicio getUserTransactions

## Type of change
- [* ] feature
- [ ] hotfix
- [ ] fix
- [ ] refactor
- [ ] chore
- [ ] docs

## How to test?
Consultar detalle de transaccion y validar los campos.

## How has this been tested?
Validar campos cuando llegan vacios
Validar tipo de datos de los campos
Validar la cantidad de campos añadidos se muestren en pantalla


## Screenshots
![image](https://github.com/Alcancia-io/alcancia/assets/8390375/3b7e2dfd-73a9-4746-935a-35a714399ed3)

## Checklist (for the reviewer)

- [* ] Does the code compile without errors or warnings?
- [ *] Does the PR is free of merge conflicts?
- [ ] Does the UI is responsive?
- [ ] Is the PR modular?